### PR TITLE
Defer icon loading

### DIFF
--- a/src/BladeBootstrapIconsServiceProvider.php
+++ b/src/BladeBootstrapIconsServiceProvider.php
@@ -9,10 +9,12 @@ class BladeBootstrapIconsServiceProvider extends ServiceProvider
 {
     public function boot()
     {
-        $this->app->make(Factory::class)->add('bootstrap-icons', [
-            'path' => __DIR__ . '/../resources/svg',
-            'prefix' => 'bi',
-        ]);
+        $this->callAfterResolving(Factory::class, function (Factory $factory) {
+            $factory->add('bootstrap-icons', [
+                'path' => __DIR__ . '/../resources/svg',
+                'prefix' => 'bi',
+            ]);
+        });
 
         if ($this->app->runningInConsole()) {
             $this->publishes([


### PR DESCRIPTION
These changes will defer the icon loading until the factory has actually been resolved. This is also the new recommended way for packages to integrate with Blade Icons. No breaking changes, the previous way will still work.