### PR TITLE
Laravel 12 support.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 /node_modules
 /vendor
+/.phpunit.cache
 composer.lock
 npm-debug.log
+phpunit.xml.dist.bak
 .phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,8 @@
         "illuminate/support": "^8.0|^9.0|^10.0|^11.0|^12.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^6.0|^7.0|^8.0|^9.0",
-        "phpunit/phpunit": "^9.0|^10.5"
+        "orchestra/testbench": "^6.0|^7.0|^8.0|^9.0|^10.1",
+        "phpunit/phpunit": "^9.0|^10.5|^11.5"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "php": "^7.4|^8.0",
         "blade-ui-kit/blade-icons": "^1.0",
-        "illuminate/support": "^8.0|^9.0|^10.0|^11.0"
+        "illuminate/support": "^8.0|^9.0|^10.0|^11.0|^12.0"
     },
     "require-dev": {
         "orchestra/testbench": "^6.0|^7.0|^8.0|^9.0",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,16 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
-         bootstrap="vendor/autoload.php"
-         colors="true">
-    <testsuites>
-        <testsuite name="Package Test Suite">
-            <directory>tests</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src/</directory>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd" bootstrap="vendor/autoload.php" colors="true" cacheDirectory=".phpunit.cache">
+  <testsuites>
+    <testsuite name="Package Test Suite">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
+  <source>
+    <include>
+      <directory suffix=".php">src/</directory>
+    </include>
+  </source>
 </phpunit>

--- a/tests/CompilesIconsTest.php
+++ b/tests/CompilesIconsTest.php
@@ -16,8 +16,7 @@ class CompilesIconsTest extends TestCase
         ];
     }
 
-    /** @test */
-    public function it_compiles_a_single_anonymous_component()
+    public function test_it_compiles_a_single_anonymous_component()
     {
         $result = svg('bi-bell-fill')->toHtml();
 
@@ -30,8 +29,7 @@ SVG;
         $this->assertSame($expected, $result);
     }
 
-    /** @test */
-    public function it_can_add_classes_to_icons()
+    public function test_it_can_add_classes_to_icons()
     {
         $result = svg('bi-bell-fill', 'text-primary')->toHtml();
 
@@ -45,8 +43,7 @@ SVG;
         $this->assertSame($expected, $result);
     }
 
-    /** @test */
-    public function it_can_add_styles_to_icons()
+    public function test_it_can_add_styles_to_icons()
     {
         $result = svg('bi-bell-fill', ['style' => 'color: #555'])->toHtml();
 


### PR DESCRIPTION
Updated dependencies and dev dependencies for Laravel 12. Renamed tests to eliminate deprecations and avoid potential backward compatibility issues that could be introduced by using attributes.